### PR TITLE
feat:  Have IM override AIM's blocking logic when there is no import map or IMO

### DIFF
--- a/.changeset/hungry-words-cut.md
+++ b/.changeset/hungry-words-cut.md
@@ -1,0 +1,5 @@
+---
+'@collagejs/vite-im': minor
+---
+
+feat: Have IM override AIM's blocking logic when there is no import map or IMO

--- a/packages/im/src/plugin-factory.ts
+++ b/packages/im/src/plugin-factory.ts
@@ -1,6 +1,6 @@
 import { promises as fs, existsSync } from 'fs';
 import type { HtmlTagDescriptor, ConfigEnv, Plugin } from 'vite';
-import type { CollageJsImPluginOptions, ImportMapsOption, Xor } from './types.js';
+import type { CollageJsImPluginOptions, Xor } from './types.js';
 import type { ImportMap } from "@collagejs/importmap";
 import { cjsAimPlugin, type CollageJsAimPluginOptions } from '@collagejs/vite-aim';
 import wjConfig from 'wj-config';
@@ -19,7 +19,6 @@ export const defaultBuildImportMap = 'src/importMap.json';
 export const defaultOptions = {
     aim: true,
     imo: true,
-    importMaps: {} as ImportMapsOption,
 };
 
 /**
@@ -43,37 +42,47 @@ export function pluginFactory(
         let viteEnv: ConfigEnv;
 
         /**
+         * Calculates the import map files that are pertinent to the occasion.  The calculation is based on the Vite 
+         * command and the `importMaps` property of the plug-in options.
+         * @param command Vite command.
+         * @returns An array of file names and a Boolean value that tells whether the file exists.
+         */
+        function getImportMapFiles(command: ConfigEnv['command']) {
+            let fileCfg = typeof imOpt.importMaps === 'string' || Array.isArray(imOpt.importMaps) ?
+                imOpt.importMaps : command === 'serve' ?
+                    imOpt.importMaps?.dev : imOpt.importMaps?.build;
+            const devDefaultFile = fileExists(defaultDevImportMap) ? defaultDevImportMap : defaultBuildImportMap;
+            if (fileCfg === undefined || typeof fileCfg === 'string') {
+                const mapFile = command === 'serve' ?
+                    (fileCfg ?? devDefaultFile) :
+                    (fileCfg ?? defaultBuildImportMap);
+                return [{
+                    file: mapFile,
+                    exists: fileExists(mapFile)
+                }];
+            }
+            return fileCfg.map(f => ({
+                file: f,
+                exists: fileExists(f)
+            }));
+        }
+
+        /**
          * Loads the import map files (JSON files) that are pertinent to the occasion.
          * @param command Vite command (serve or build).
          * @returns An array of string values, where each value is the content of one import map file.
          */
         async function loadImportMaps(command: ConfigEnv['command']) {
-            let fileCfg = command === 'serve' ? imOpt.importMaps?.dev : imOpt.importMaps?.build;
-            const defaultFile = fileExists(defaultDevImportMap) ? defaultDevImportMap : defaultBuildImportMap;
-            if (fileCfg === undefined || typeof fileCfg === 'string') {
-                const mapFile = command === 'serve' ?
-                    (fileCfg ?? defaultFile) :
-                    (fileCfg ?? defaultBuildImportMap);
-                if (!fileExists(mapFile)) {
-                    console.warn(`Import map file ${mapFile} does not exist.  No import map will be injected into the HTML page.`);
-                    return null;
+            const files = getImportMapFiles(command);
+            const contents = [] as string[];
+            for (let f of files) {
+                if (!f.exists) {
+                    continue;
                 }
-                const contents = await readFile(mapFile, {
-                    encoding: 'utf8'
-                }) as string;
-                return [contents];
+                const content = await readFile(f.file, { encoding: 'utf8' });
+                contents.push(content);
             }
-            else {
-                const fileContents: string[] = [];
-                for (let f of fileCfg) {
-                    if (!fileExists(f)) {
-                        continue;
-                    }
-                    const contents = await readFile(f, { encoding: 'utf8' }) as string;
-                    fileContents.push(contents);
-                }
-                return fileContents.length > 0 ? fileContents : null;
-            }
+            return contents.length > 0 ? contents : null;
         }
 
         /**
@@ -241,6 +250,13 @@ export function pluginFactory(
                     const im = await buildImportMap('build');
                     if (im) {
                         cfg.importMap = im;
+                    }
+                    if (!imOpt.imo || !getImportMapFiles('serve').some(f => f.exists)) {
+                        cfg.shouldBlock = () => {
+                            // Since there will be no IMO script or no import map,
+                            // blocking requests is pointless.
+                            return false;
+                        }
                     }
                     return cfg;
                 })

--- a/packages/im/src/types.ts
+++ b/packages/im/src/types.ts
@@ -21,6 +21,11 @@ export type ImportMapsOption = {
 };
 
 /**
+ * Defines the full set of options that are accepted for import maps in root projects.
+ */
+export type ImportMapsSpec = ImportMapsOption | string | string[];
+
+/**
  * Defines the various ways the source for `@collagejs/imo` can be specified.
  */
 export type ImoSource = boolean | string | (() => string);
@@ -43,9 +48,9 @@ export type ImoSpec = {
 export type CollageJsImPluginOptions = {
     /**
      * Specifies the type and import map files to inject into the HTML page's HEAD element.
-     * @default { build: "importmap.json" }
+     * @default 'src/importMap.json'
      */
-    importMaps?: ImportMapsOption | undefined;
+    importMaps?: ImportMapsSpec | undefined;
     /**
      * Controls the inclusion of the `@collagejs/imo` package.  If set to `true`, or not specified at all, 
      * `@collagejs/imo` will be included using the package's latest version.  In order to include a specific 

--- a/packages/im/src/types.ts
+++ b/packages/im/src/types.ts
@@ -48,7 +48,7 @@ export type ImoSpec = {
 export type CollageJsImPluginOptions = {
     /**
      * Specifies the type and import map files to inject into the HTML page's HEAD element.
-     * @default 'src/importMap.json'
+     * @default { dev: 'src/importMap.dev.json', build: 'src/importMap.json' }
      */
     importMaps?: ImportMapsSpec | undefined;
     /**

--- a/packages/im/tests/plugin-factory.test.ts
+++ b/packages/im/tests/plugin-factory.test.ts
@@ -5,7 +5,7 @@ import type { CollageJsImPluginOptions, ImportMapsOption } from "../src/types.js
 import type { PathLike } from 'fs';
 import type { ImportMap } from '@collagejs/importmap';
 import type { ImoUiFactoryOptions } from '@collagejs/imo';
-import type { PluginOptions } from '@collagejs/vite-aim';
+import type { CollageJsAimPluginOptions } from '@collagejs/vite-aim';
 import { imoUiOptionsId } from '@collagejs/imo/const';
 
 type ConfigHandler = (this: void, config: UserConfig, env: ConfigEnv) => Promise<UserConfig>
@@ -202,7 +202,7 @@ describe('pluginFactory', () => {
     for (let tc of defaultImportMapTestData) {
         it(`Should pick the contents of the default file "${tc.fileName}" if the file exists on ${tc.viteCmd} as the contents of the import map script.`, () => defaultImportMapTest(tc.fileName, tc.viteCmd));
     }
-    const importMapTest = async (propertyName: Exclude<keyof ImportMapsOption, 'type'>, viteCmd: ConfigEnv['command']) => {
+    it.each(viteCommands)("Should pick the contents of the single import map file specified if the file exists on %s as the contents of the import map script.", async (viteCmd) => {
         // Arrange.
         const fileName = 'customImportMap.json';
         const fileExists = (x: PathLike) => x === fileName;
@@ -224,8 +224,54 @@ describe('pluginFactory', () => {
             }
             return Promise.resolve(JSON.stringify(importMap));
         }) as Parameters<typeof pluginFactory>[0];
-        const pluginOptions: CollageJsImPluginOptions = { importMaps: {} };
-        pluginOptions.importMaps![propertyName] = fileName;
+        const pluginOptions = { importMaps: fileName };
+        const plugin = (await pluginFactory(readFile, fileExists)(pluginOptions))[0];
+        const env: ConfigEnv = { command: viteCmd, mode: 'development' };
+        await(plugin.config as ConfigHandler)({}, env);
+        const ctx = { path: '', filename: '' };
+
+        // Act.
+        const xForm = await asHandlerDef(plugin.transformIndexHtml).handler('', ctx);
+
+        // Assert.
+        expect(fileRead).to.equal(true);
+        expect(xForm).to.not.equal(null);
+        expect(xForm).to.not.equal(undefined);
+        if (xForm && typeof xForm !== 'string' && !Array.isArray(xForm)) {
+            const firstTag = xForm.tags[0];
+            expect(firstTag).to.not.equal(undefined);
+            expect(firstTag!.tag).to.equal('script');
+            const parsedImportMap = JSON.parse(firstTag!.children as string);
+            expect(parsedImportMap).to.be.deep.equal(importMap);
+        }
+        else {
+            throw new Error('TypeScript narrowing suddenly routed the test elsewhere!');
+        }
+    });
+    const importMapTest = async (propertyName: keyof ImportMapsOption, viteCmd: ConfigEnv['command']) => {
+        // Arrange.
+        const fileName = 'customImportMap.json';
+        const fileExists = (x: PathLike) => x === fileName;
+        const importMap = {
+            imports: {
+                '@a/b': 'cd'
+            },
+            scopes: {
+                pickyModule: {
+                    '@a/b': 'ef'
+                }
+            },
+            integrity: {}
+        };
+        let fileRead = false;
+        const readFile = ((x: string) => {
+            if (x === fileName) {
+                fileRead = true;
+            }
+            return Promise.resolve(JSON.stringify(importMap));
+        }) as Parameters<typeof pluginFactory>[0];
+        const pluginOptions = { importMaps: {} as ImportMapsOption };
+        pluginOptions.importMaps[propertyName] = fileName;
         const plugin = (await pluginFactory(readFile, fileExists)(pluginOptions))[0];
         const env: ConfigEnv = { command: viteCmd, mode: 'development' };
         await (plugin.config as ConfigHandler)({}, env);
@@ -249,7 +295,7 @@ describe('pluginFactory', () => {
             throw new Error('TypeScript narrowing suddenly routed the test elsewhere!');
         }
     };
-    const importMapTestData: { propertyName: Exclude<keyof ImportMapsOption, 'type'>, viteCmd: ConfigEnv['command'] }[] = [
+    const importMapTestData: { propertyName: keyof ImportMapsOption, viteCmd: ConfigEnv['command'] }[] = [
         {
             propertyName: 'dev',
             viteCmd: 'serve'
@@ -262,7 +308,7 @@ describe('pluginFactory', () => {
     for (let tc of importMapTestData) {
         it(`Should pick the contents of the specified file in the "importMaps.${tc.propertyName}" configuration property on ${tc.viteCmd}.`, () => importMapTest(tc.propertyName, tc.viteCmd));
     }
-    const importMapTestMultiple = async (map1: ImportMap, map2: ImportMap, expectedMap: ImportMap, propertyName: Exclude<keyof ImportMapsOption, 'type'>, viteCmd: ConfigEnv['command']) => {
+    const importMapTestMultiple = async (map1: ImportMap, map2: ImportMap, expectedMap: ImportMap, propertyName: keyof ImportMapsOption, viteCmd: ConfigEnv['command']) => {
         // Arrange.
         expectedMap.integrity = {};
         const fileNames = ['A.json', 'B.json'];
@@ -278,8 +324,8 @@ describe('pluginFactory', () => {
             }
             return Promise.resolve(JSON.stringify(importMaps[x]));
         }) as Parameters<typeof pluginFactory>[0];
-        const pluginOptions: CollageJsImPluginOptions = { importMaps: {} };
-        pluginOptions.importMaps![propertyName] = fileNames;
+        const pluginOptions = { importMaps: {} as ImportMapsOption };
+        pluginOptions.importMaps[propertyName] = fileNames;
         const plugin = (await pluginFactory(readFile, fileExists)(pluginOptions))[0];
         const env: ConfigEnv = { command: viteCmd, mode: 'development' };
         await (plugin.config as ConfigHandler)({}, env);
@@ -307,7 +353,7 @@ describe('pluginFactory', () => {
         map1: ImportMap,
         map2: ImportMap,
         expectedMap: ImportMap,
-        propertyName: Exclude<keyof ImportMapsOption, 'type'>,
+        propertyName: keyof ImportMapsOption,
         viteCmd: ConfigEnv['command']
     }[] = [
             {
@@ -1009,7 +1055,7 @@ describe('pluginFactory', () => {
         });
         it("Should allow passing AIM options via the first argument of the plug-in factory.", async () => {
             // Arrange.
-            const aimOptions: PluginOptions = { banner: false, allowedOrigins: ['https://example.com'] };
+            const aimOptions: CollageJsAimPluginOptions = { banner: false, allowedOrigins: ['https://example.com'] };
             const fileExists = () => false;
 
             // Act.
@@ -1018,6 +1064,54 @@ describe('pluginFactory', () => {
             // Assert.
             expect(plugin).toBeTruthy();
             expect(mockedAimPlugin.mock.calls[0][0]).toEqual(expect.objectContaining(aimOptions));
+        });
+        it.each([
+            {
+                text: 'there is no import map',
+                fileExists: false,
+                options: { imo: true },
+                shouldConfigure: true,
+                confText: 'configure'
+            },
+            {
+                text: 'there is no IMO script',
+                fileExists: true,
+                options: { imo: false },
+                shouldConfigure: true,
+                confText: 'configure'
+            },
+            {
+                text: 'there is an import map and an IMO script',
+                fileExists: true,
+                options: { imo: true },
+                shouldConfigure: false,
+                confText: 'not configure'
+            }
+        ])("Should $confText AIM's 'shouldBlock' option to always return false if $text .", async ({ fileExists, options, shouldConfigure }) => {
+            // Arrange.
+            const fileExistsFn = () => fileExists;
+            const importMap = {
+                imports: {
+                    '@a/b': 'cd'
+                },
+            };
+            const readFile = (() => {
+                return Promise.resolve(JSON.stringify(importMap));
+            }) as unknown as Parameters<typeof pluginFactory>[0];
+
+            // Act.
+            const plugin = (await pluginFactory(readFile, fileExistsFn)(options))[1];
+
+            // Assert.
+            expect(plugin).toBeTruthy();
+            const shouldBlockFn = mockedAimPlugin.mock.calls[0][0].shouldBlock;
+            if (shouldConfigure) {
+                expect(shouldBlockFn).toBeDefined();
+                expect(shouldBlockFn()).toBe(false);
+            }
+            else {
+                expect(shouldBlockFn).toBeUndefined();
+            }
         });
     });
 });


### PR DESCRIPTION
Closes #55, but in a different way to the proposed one.

Instead, it uses AIM's new `shouldBlock` option to escape, in runtime, of any blocks.

It also brings back the possiblity of specifying the `importMaps` option as a single string.  Unsure why this was dropped before.