### PR TITLE
feat(aim):  Allow HTTP DELETE request on import map endpoint

### DIFF
--- a/.changeset/grumpy-queens-type.md
+++ b/.changeset/grumpy-queens-type.md
@@ -1,0 +1,5 @@
+---
+'@collagejs/vite-aim': minor
+---
+
+feat(aim): Allow HTTP DELETE request on import map endpoint

--- a/packages/aim/src/plugin-factory.ts
+++ b/packages/aim/src/plugin-factory.ts
@@ -45,7 +45,7 @@ export function cjsAimPlugin(options: CollageJsAimPluginOptions = {}): Plugin {
     let config: ResolvedConfig;
     let importMapResolver: Resolver | undefined;
     let logger: Logger;
-    const externalizedModules = new Set<string>();
+    const externalizedModules = new Map<string, string>();
 
     // ManualResetEvent to coordinate request blocking/unblocking
     const importMapReadyEvent = new ManualResetEvent(); // Initially unsignaled
@@ -138,11 +138,20 @@ export function cjsAimPlugin(options: CollageJsAimPluginOptions = {}): Plugin {
                 return true;
             };
 
-            // Import map endpoint - receives POST from @collagejs/imo
-            devServer.middlewares.use(importMapEndpoint, (req, res) => {
-                if (req.method === 'POST') {
-                    const origin = req.headers.origin || req.headers.referer;
+            function deleteImportMap() { 
+                importMapResolver = undefined;
+                const totalExternalized = externalizedModules.size;
+                externalizedModules.clear();
+                devServer.moduleGraph.invalidateAll();
+                importMapReadyEvent.reset();
+                logger.info(fmt.success(`Import map deleted. All subsequent requests will be blocked until a new import map is received.`), { timestamp: true });
+                return totalExternalized;
+            }
 
+            // Import map endpoint - receives POST and DELETE from @collagejs/imo
+            devServer.middlewares.use(importMapEndpoint, async (req, res) => {
+                const origin = req.headers?.origin || req.headers?.referer;
+                if (req.method === 'POST' || req.method === 'DELETE') {
                     // Security check
                     if (!isOriginAllowed(origin)) {
                         logger.warn(`Rejected import map from unauthorized origin: ${pc.red(origin)}`, { timestamp: true });
@@ -150,7 +159,13 @@ export function cjsAimPlugin(options: CollageJsAimPluginOptions = {}): Plugin {
                         res.end(JSON.stringify({ error: 'Origin not allowed' }));
                         return;
                     }
-
+                }
+                if (req.method === 'DELETE') {
+                    const totalExternalized = deleteImportMap();
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ success: true, externalizedModulesDeleted: totalExternalized }));
+                }
+                else if (req.method === 'POST') {
                     let body = '';
                     req.on('data', chunk => {
                         body += chunk.toString();
@@ -264,8 +279,8 @@ export function cjsAimPlugin(options: CollageJsAimPluginOptions = {}): Plugin {
             if (resolved === null || resolved === id) {
                 return null;
             }
-            const finalId = externalizationMode === 'resolved' ? resolved : id;
-            externalizedModules.add(finalId);
+            const finalId = externalizationMode === 'resolved' || config.command === 'serve' ? resolved : id;
+            externalizedModules.set(id, finalId);
             return {
                 id: finalId,
                 external: true

--- a/packages/aim/src/types.ts
+++ b/packages/aim/src/types.ts
@@ -53,8 +53,8 @@ export interface CollageJsAimPluginOptions {
      * Whether to externalize module identifiers by their import map ID or by their resolved path.
      * 
      * > ⚠️ Only has an effect when the `importMap` option is specified while in build mode.  If there is no import 
-     * map to work with, this option plays no part in the externalization process.  Works in serve mode as long as 
-     * Vite's development server receives an import map to work with (usually provided by `@collagejs/imo`).
+     * map to work with, this option plays no part in the externalization process.  Serve mode always uses the 
+     * `'resolved'` behavior.
      * 
      * ### Possible Values
      * 

--- a/packages/aim/tests/plugin-factory.test.ts
+++ b/packages/aim/tests/plugin-factory.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { describe, test, expect, vi, beforeAll, beforeEach, afterEach, type Mock } from "vitest";
 import { cjsAimPlugin, defaultImportMapEndpoint, pluginName } from "../src/plugin-factory";
 import { createServer } from "vite";
 import type { ConfigEnv, ResolvedConfig, ServerHook, ViteDevServer, Connect } from "vite";
@@ -100,9 +100,16 @@ describe("cjsAimPlugin", () => {
                     'Access-Control-Allow-Headers': 'Content-Type'
                 });
             });
-            test("Should return a 405 response for HTTP requests that are not OPTIONS or POST.", () => {
+            test.each([
+                'GET',
+                'PUT',
+                'PATCH',
+                'HEAD',
+                'TRACE',
+                'CONNECT',
+            ])("Should return a 405 response for HTTP %s requests.", (method) => {
                 const req: Connect.IncomingMessage = {
-                    method: "GET",
+                    method,
                     url: defaultImportMapEndpoint
                 } as Connect.IncomingMessage;
                 const res = {
@@ -208,6 +215,62 @@ describe("cjsAimPlugin", () => {
                 });
                 expect(res.end).toHaveBeenCalledOnce();
             });
+            test("Should return a 200 response for DELETE requests.", () => {
+                const req: Connect.IncomingMessage = {
+                    method: "DELETE",
+                    url: defaultImportMapEndpoint,
+                    headers: {
+                        origin: 'http://localhost'
+                    }
+                } as Connect.IncomingMessage;
+                const res = {
+                    statusCode: 0,
+                    writeHead: vi.fn(),
+                    end: vi.fn()
+                } as unknown as ServerResponse;
+                handler(req, res);
+                expect(res.writeHead).toHaveBeenCalledWith(200, {
+                    'Content-Type': 'application/json',
+                });
+                expect(res.end).toHaveBeenCalledOnce();
+                expect(JSON.parse((res.end as unknown as Mock).mock.calls[0][0])).toEqual({
+                    success: true,
+                    externalizedModulesDeleted: expect.any(Number)
+                });
+            });
+            test.each([
+                'POST',
+                'DELETE',
+            ])("Should return a 403 response for %s requests from unauthorized origins.", (method) => {
+                const im = JSON.stringify({
+                    imports: { }
+                });
+                const req: Connect.IncomingMessage = {
+                    method,
+                    url: defaultImportMapEndpoint,
+                    headers: {
+                        origin: 'http://unauthorized.com'
+                    },
+                    on: vi.fn((event, callback) => {
+                        if (event === 'data') {
+                            callback(im);
+                        }
+                        else if (event === 'end') {
+                            callback();
+                        }
+                    }),
+                } as unknown as Connect.IncomingMessage;
+                const res = {
+                    statusCode: 0,
+                    writeHead: vi.fn(),
+                    end: vi.fn()
+                } as unknown as ServerResponse;
+                handler(req, res);
+                expect(res.writeHead).toHaveBeenCalledWith(403, {
+                    'Content-Type': 'application/json',
+                });
+                expect(res.end).toHaveBeenCalledOnce();
+            });
         });
         describe("Blocking Middleware", () => {
             let handler: Connect.NextHandleFunction;
@@ -215,7 +278,7 @@ describe("cjsAimPlugin", () => {
             const pathEx = '/let/me/pass';
             beforeAll(async () => {
                 devServer = await createServer();
-                const plugin = await preparePlugin({ importMapTimeout: 150, pathExceptions: [pathEx] });
+                const plugin = await preparePlugin({ importMapTimeout: 0, pathExceptions: [pathEx] });
                 // @ts-expect-error TS2684
                 await (plugin.configureServer as ServerHook)(devServer);
                 // @ts-expect-error
@@ -323,6 +386,40 @@ describe("cjsAimPlugin", () => {
                 const next = vi.fn();
                 handler(req, res, next);
                 expect(next).toHaveBeenCalledOnce();
+            });
+            test("Should go back to blocking requests if the import map is deleted.", async () => {
+                await postImportMap();
+                const req1: Connect.IncomingMessage = {
+                    method: 'GET',
+                    url: 'some/code.js'
+                } as Connect.IncomingMessage;
+                const next1 = vi.fn();
+                const p1 = handler(req1, res, next1);
+                expect(next1).toHaveBeenCalledOnce();
+                await p1;
+                const deleteReq: Connect.IncomingMessage = {
+                    method: 'DELETE',
+                    url: defaultImportMapEndpoint,
+                    headers: {
+                        origin: 'http://localhost'
+                    },
+                } as Connect.IncomingMessage;
+                const deleteRes = {
+                    statusCode: 0,
+                    writeHead: vi.fn(),
+                    end: vi.fn()
+                } as unknown as ServerResponse;
+                await imHandler(deleteReq, deleteRes);
+                expect(deleteRes.writeHead).toHaveBeenCalledWith(200, expect.any(Object));
+                const req2: Connect.IncomingMessage = {
+                    method: 'GET',
+                    url: 'some/code.js'
+                } as Connect.IncomingMessage;
+                const next2 = vi.fn();
+                const p2 = handler(req2, res, next2);
+                expect(next2).not.toHaveBeenCalled();
+                await p2;
+                expect(next2).toHaveBeenCalledOnce();
             });
             describe('shouldBlock', async () => {
                 const shouldBlockFn = vi.fn();
@@ -466,9 +563,6 @@ describe("cjsAimPlugin", () => {
                     });
                     expect(res.end).toHaveBeenCalledOnce();
                     const resolved = await (plugin.resolveId as ViteResolveIdHookFn)(id, undefined, { ssr: false });
-                    if (expected && mode === 'id') {
-                        expected.id = id;
-                    }
                     expect(resolved).toEqual(expected);
                 });
             });
@@ -500,7 +594,7 @@ describe("cjsAimPlugin", () => {
                 }
                 expect(resolved).toEqual(expected);
             });
-            test(`Should externalize by returning the ${mode === 'id' ? 'same ID' : 'resolved ID'} while in '${mode}' externalization mode.`, async () => {
+            test(`Should externalize by returning the ${mode === 'id' ? 'same ID' : 'resolved ID'} while in '${mode}' externalization mode and Vite's build mode.`, async () => {
                 const plugin = cjsAimPlugin({ importMap: { imports: { 'foo': '/foo.js' } }, externalizationMode: mode });
                 await (plugin.configResolved as ViteConfigResolvedHookFn)({ command: 'build' } as ResolvedConfig);
                 const resolved = await (plugin.resolveId as ViteResolveIdHookFn)('foo', undefined, { ssr: false });


### PR DESCRIPTION
Closes #54, but does so using `moduleGraph.invalidateAll()`, as I could not figure out how to target the specific modules previously externalized.

Also ignores the externalization mode while in serve mode, as returning the same ID doesn't work in this mode.